### PR TITLE
Release docker image for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 sudo: required
 
+arch:
+  - amd64
+  - arm64
+
 services:
 - docker
 
 script:
 - >
-- docker build -t wise2c/kubeadm-version:$TRAVIS_BRANCH .
+- if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+  arch="-$TRAVIS_CPU_ARCH";
+  else
+  arch="";
+  fi
+- docker build -t wise2c/kubeadm-version:$TRAVIS_BRANCH$arch .
 - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-- docker push wise2c/kubeadm-version:$TRAVIS_BRANCH
-- docker run --rm --name=kubeadm-version wise2c/kubeadm-version:$TRAVIS_BRANCH kubeadm config images list
+- docker push wise2c/kubeadm-version:$TRAVIS_BRANCH$arch
+- docker run --rm --name=kubeadm-version wise2c/kubeadm-version:$TRAVIS_BRANCH$arch kubeadm config images list

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
 FROM centos:8.1.1911
-COPY kubernetes.repo /etc/yum.repos.d
+COPY / /kubeadm-version
+RUN if [ `uname -m` = "aarch64" ] ; then \
+       cp kubeadm-version/kubernetes_arm64.repo /etc/yum.repos.d; \
+    else \
+       cp kubeadm-version/kubernetes.repo /etc/yum.repos.d; \
+    fi
 RUN yum -y install kubeadm-1.19.4

--- a/kubernetes_arm64.repo
+++ b/kubernetes_arm64.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-aarch64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
The following files have been modified and added:

- Added architecture arm64 in **.travis.yml** file to build the image for arm64 with the name “**wise2c/kubeadm-version:$TRAVIS_BRANCH-arm64**”

- In **DOCKERFILE** added the check to copy **kubernetes_arm64.repo** to **/etc/yum.repos.d**

- Added **kubernetes_arm64.repo** file which is same as **kubernetes.repo** but modified it for arm64.